### PR TITLE
included support for PKCS8 format

### DIFF
--- a/modcert
+++ b/modcert
@@ -4,14 +4,16 @@ VERBOSE=${VERBOSE:-false}
 MODCERT="$0"
 TARGETS=( "$@" )
 
+PWD="Proc-Type: 4,ENCRYPTED"
 BEG="-----BEGIN"
-KEY="-----BEGIN RSA PRIVATE KEY-----"
 CSR="-----BEGIN CERTIFICATE REQUEST-----"
 CRT="-----BEGIN CERTIFICATE-----"
-PWD="Proc-Type: 4,ENCRYPTED"
+KEY_PKCS1="-----BEGIN RSA PRIVATE KEY-----"
+KEY_PKCS8="-----BEGIN PRIVATE KEY-----"
 
 declare -A LINES=( \
-    ["$KEY"]="rsa" \
+    ["$KEY_PKCS1"]="rsa" \
+    ["$KEY_PKCS8"]="rsa" \
     ["$CSR"]="req" \
     ["$CRT"]="x509" \
 )

--- a/ssl-unused
+++ b/ssl-unused
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# File: ssl-unused
+# Summary:
+#  - Use autocert to list all domains we have SSL certs for
+#  - See if we can resolve each CN (common name)
+#  - If host resolution fails, the site may 
+# By Daniel Hartnell <dhartnell@mozilla.com>
+
+# This parses the autocert verbose output and gathers CNs
+DOMAINS=$(autocert ls -v1  | grep common_name | \
+  awk -F ': ' '{print $2}' | grep -v "^\'\*")
+
+for domain in $DOMAINS
+do
+  host $domain > /dev/null 2>&1
+  if [ $? -ne 0 ]
+  then
+    echo "Unable to resolve host: $domain"
+  fi
+done


### PR DESCRIPTION
This should allow us to properly handle private keys in the PKCS#8 format. It looks like the `openssl rsa` command supports PKCS#1 and PKCS#8 formats by default. Since that's the case, I've simply renamed the `KEY` variable to `KEY_PKCS1` (I believe that should be true in most / all cases) and included a new `KEY_PKCS8` variable so `modcert` knows what to look for.

You can read a little more about that here: https://wiki.openssl.org/index.php/Manual:Rsa(1)

I've also sorted the variable declarations in a new order. Just wanted to keep the alignment all nice and neat.

Let me know if anything needs to change!